### PR TITLE
Give an error if no paths were specified

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub struct Args {
 
     /// files to search links in.
     #[argh(positional)]
-    paths: Vec<PathBuf>,
+    pub paths: Vec<PathBuf>,
 }
 
 /// Takes an `Args` instance to transform the paths it contains accordingly

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,13 @@
+use std::process;
+use cargo_intraconv::Args;
+
 fn main() {
-    cargo_intraconv::run(argh::from_env())
+    let args: Args = argh::from_env();
+    // TODO(https://github.com/google/argh/issues/61): this shouldn't be necessary
+    if args.paths.is_empty() {
+        // TODO: it seems like `argh` should expose a way to do this ...
+        eprintln!("usage: cargo-intraconv [<paths...>] [-c <crate>] [-a]");
+        process::exit(1);
+    }
+    cargo_intraconv::run(args)
 }


### PR DESCRIPTION
Example output:

```
$ cargo-intraconv 
usage: cargo-intraconv [<paths...>] [-c <crate>] [-a]
```